### PR TITLE
Relax none generic types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nullshield",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -30,7 +30,7 @@
     "@types/marked": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz",
-      "integrity": "sha1-WDwiPdMzhaHdoBqvd7DNBBHEtSQ=",
+      "integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg==",
       "dev": true
     },
     "@types/minimatch": {
@@ -366,7 +366,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -434,7 +434,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -450,7 +450,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.3"
@@ -465,7 +465,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "ecc-jsbn": {
@@ -487,7 +487,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esutils": {
@@ -579,7 +579,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -599,7 +599,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "handlebars": {
@@ -755,7 +755,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -887,7 +887,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -2738,7 +2738,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nullshield",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A package containing Option and Result types",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/option.ts
+++ b/src/option.ts
@@ -474,13 +474,15 @@ export interface OptT<T> {
  */
 export namespace OptionT {
   /**
-   * Returns a `None` value if `val` is `null` or `undefined`, otherwise returns a `Some`
-   * value containing `val`.
+   * Returns a `Some` value containing `val`.
    *
    * @param {T} val
-   * @returns {OptT<any>}
+   * @returns {OptT<T>}
    */
-  export function some<T>(val: T): OptT<any> {
+  export function some<T>(val: T): OptT<T> {
+    if (val === null || typeof val === 'undefined') {
+      throw new TypeError('Cannot create a `SomeT` containing either `null` or `undefined`.');
+    }
     return getSome(val);
   }
 
@@ -491,5 +493,16 @@ export namespace OptionT {
    */
   export function none(): OptT<any> {
     return getNone();
+  }
+
+  /**
+   * Returns a `None` value if `val` is `null` or `undefined`, otherwise returns a `Some`
+   * value containing `val`.
+   *
+   * @param {T} val
+   * @returns {OptT<any>}
+   */
+  export function wrap<T>(val: T): OptT<any> {
+    return getSome(val)
   }
 }

--- a/src/option.ts
+++ b/src/option.ts
@@ -480,7 +480,7 @@ export namespace OptionT {
    * @param {T} val
    * @returns {OptT<any>}
    */
-  export function some<T>(val: T) {
+  export function some<T>(val: T): OptT<any> {
     return getSome(val);
   }
 
@@ -489,7 +489,7 @@ export namespace OptionT {
    *
    * @returns {OptT<any>}
    */
-  export function none() {
+  export function none(): OptT<any> {
     return getNone();
   }
 }

--- a/src/option/none.ts
+++ b/src/option/none.ts
@@ -95,8 +95,8 @@ export class NoneT<T> implements OptT<T> {
 /**
  * Returns a [[NoneT]] instance.
  *
- * @returns {OptT<T>}
+ * @returns {OptT<any>}
  */
-export function getNone<T>(): OptT<T> {
+export function getNone(): OptT<any> {
   return new NoneT();
 }

--- a/src/option/some.ts
+++ b/src/option/some.ts
@@ -112,9 +112,9 @@ export class SomeT<T> implements OptT<T> {
  * containing `val`.
  *
  * @param {T} val The value with which to create the [[NoneT]] or [[SomeT]].
- * @returns {OptT<T>}
+ * @returns {OptT<any>}
  */
-export function getSome<T>(val: T): OptT<T> {
+export function getSome<T>(val: T): OptT<any> {
   if (val === null || typeof val === 'undefined') {
     return new NoneT();
   }

--- a/test/option/both.ts
+++ b/test/option/both.ts
@@ -1,0 +1,47 @@
+import 'mocha';
+import { OptionT } from '../../src/index';
+import { expect } from 'chai';
+import { expectASome, expectANone } from './util';
+import { OptT } from "../../src/option";
+
+describe('#OptionT.some and #OptionT.none', () => {
+  it('should be compatible with one another in terms of types', () => {
+    const one = OptionT.some(1);
+    const nope = OptionT.none();
+
+    expectASome(one);
+    expectANone(nope);
+
+    function processOpt(opt: OptT<number>) {
+      return opt;
+    }
+
+    const oneAgain = processOpt(one);
+    const nopeAgain = processOpt(nope);
+
+    expectASome(oneAgain);
+    expectANone(nopeAgain);
+  });
+
+  it('should be of the same type when a some turns into a none', () => {
+    const one = OptionT.some(undefined);
+    const two = OptionT.some(null);
+    const nope = OptionT.none();
+
+    expectANone(one);
+    expectANone(two);
+    expectANone(nope);
+
+    function processOpt(opt: OptT<string>) {
+      return opt;
+    }
+
+    const oneAgain = processOpt(one);
+    const twoAgain = processOpt(two);
+    const nopeAgain = processOpt(nope);
+
+    expectANone(oneAgain);
+    expectANone(twoAgain);
+    expectANone(nopeAgain);
+  });
+});

--- a/test/option/both.ts
+++ b/test/option/both.ts
@@ -24,8 +24,8 @@ describe('#OptionT.some and #OptionT.none', () => {
   });
 
   it('should be of the same type when a some turns into a none', () => {
-    const one = OptionT.some(undefined);
-    const two = OptionT.some(null);
+    const one = OptionT.wrap(undefined);
+    const two = OptionT.wrap(null);
     const nope = OptionT.none();
 
     expectANone(one);

--- a/test/option/some.ts
+++ b/test/option/some.ts
@@ -12,15 +12,20 @@ describe('#OptionT', () => {
 
     expect(OptionT.some).to.be.a('function');
   });
+
+  it('should be an object with wrap', () => {
+    expect(OptionT)
+      .to.be.a('object')
+      .that.has.property('wrap');
+
+    expect(OptionT.wrap).to.be.a('function');
+  });
 });
 
 describe('#OptionT.some', () => {
-  it('should return a none when given null or undefined', () => {
-    const one = OptionT.some(null);
-    expectANone(one);
-
-    const two = OptionT.some(undefined);
-    expectANone(two);
+  it('should throw an error when given null or undefined', () => {
+    expect(() => { OptionT.some(null); }).to.throw();
+    expect(() => { OptionT.some(undefined); }).to.throw();
   });
 
   it('should have the function isSome', () => {


### PR DESCRIPTION
This is so that `none` and `some` types are truly compatible with each other.

Previously a function like this:
```
function foo(opt: OptT<number>) {...}
```
would not accept a `none` as an argument because `OptT<{}>` isn't the same as `OptT<number>`.