### PR TITLE
make sure to build before we publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "prettier": "prettier --write ./src/*",
     "prebuild": "npm run clean",
+    "prepublish": "npm run build",
     "build": "tsc --module commonjs && rollup -c rollup.config.ts && typedoc --out docs --target es6 --theme minimal --mode file src",
     "start": "rollup -c rollup.config.ts -w",
     "test": "npm run clean && jest",


### PR DESCRIPTION
this is needed because if we don't the files in "dist" won't exist and
our package won't contain anything at all when published.